### PR TITLE
Allow adding constant Prometheus labels to all metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Kubernetes users may want to use the Helm chart to deploy Kafka Minion: https://
 | KAFKA_TLS_CERT_FILE_PATH | Path to the TLS cert file | (No default) |
 | KAFKA_TLS_INSECURE_SKIP_TLS_VERIFY | If true, TLS accepts any certificate presented by the server and any host name in that certificate. | true |
 | KAFKA_TLS_PASSPHRASE | Passphrase to decrypt the TLS Key | (No default) |
+| PROMETHEUS_CONST_LABELS | Prometheus [Constant Labels](https://pkg.go.dev/github.com/prometheus/client_golang/prometheus?tab=doc#example-GaugeFunc-ConstLabels) which are added to all metrics. Take a comma-separated string of key-value pairs e.g. "environment:integration,name:cluster-1" | "" |
 
 ### Grafana Dashboard
 

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -131,14 +131,18 @@ func NewCollector(opts *options.Options, storage *storage.MemoryStorage) *Collec
 		[]string{"broker_id"}, opts.ConstLabels,
 	)
 
+	buildInfoLabels := make(map[string]string)
+	for k, v := range opts.ConstLabels {
+		buildInfoLabels[k] = v
+	}
+	buildInfoLabels["version"] = opts.Version
+
 	// General metrics
 	buildInfo := prometheus.NewGauge(prometheus.GaugeOpts{
-		Namespace: opts.MetricsPrefix,
-		Name:      "build_info",
-		Help:      "Build Info about Kafka Minion",
-		ConstLabels: prometheus.Labels{
-			"version": opts.Version,
-		},
+		Namespace:   opts.MetricsPrefix,
+		Name:        "build_info",
+		Help:        "Build Info about Kafka Minion",
+		ConstLabels: buildInfoLabels,
 	})
 	buildInfo.Set(1)
 	prometheus.MustRegister(buildInfo)

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -62,73 +62,73 @@ func NewCollector(opts *options.Options, storage *storage.MemoryStorage) *Collec
 	groupPartitionOffsetDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(opts.MetricsPrefix, "group_topic_partition", "offset"),
 		"Newest committed offset of a consumer group for a partition",
-		[]string{"group", "group_base_name", "group_is_latest", "group_version", "topic", "partition"}, prometheus.Labels{},
+		[]string{"group", "group_base_name", "group_is_latest", "group_version", "topic", "partition"}, opts.ConstLabels,
 	)
 	groupPartitionCommitCountDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(opts.MetricsPrefix, "group_topic_partition", "commit_count"),
 		"Number of commits of a consumer group for a partition",
-		[]string{"group", "group_base_name", "group_is_latest", "group_version", "topic", "partition"}, prometheus.Labels{},
+		[]string{"group", "group_base_name", "group_is_latest", "group_version", "topic", "partition"}, opts.ConstLabels,
 	)
 	groupPartitionLastCommitDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(opts.MetricsPrefix, "group_topic_partition", "last_commit"),
 		"Timestamp when consumer group last committed an offset for a partition",
-		[]string{"group", "group_base_name", "group_is_latest", "group_version", "topic", "partition"}, prometheus.Labels{},
+		[]string{"group", "group_base_name", "group_is_latest", "group_version", "topic", "partition"}, opts.ConstLabels,
 	)
 	groupPartitionExpiresAtDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(opts.MetricsPrefix, "group_topic_partition", "expires_at"),
 		"Timestamp when this offset will expire if there won't be further commits",
-		[]string{"group", "group_base_name", "group_is_latest", "group_version", "topic", "partition"}, prometheus.Labels{},
+		[]string{"group", "group_base_name", "group_is_latest", "group_version", "topic", "partition"}, opts.ConstLabels,
 	)
 	groupPartitionLagDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(opts.MetricsPrefix, "group_topic_partition", "lag"),
 		"Number of messages the consumer group is behind for a partition",
-		[]string{"group", "group_base_name", "group_is_latest", "group_version", "topic", "partition"}, prometheus.Labels{},
+		[]string{"group", "group_base_name", "group_is_latest", "group_version", "topic", "partition"}, opts.ConstLabels,
 	)
 	groupTopicLagDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(opts.MetricsPrefix, "group_topic", "lag"),
 		"Number of messages the consumer group is behind for a topic",
-		[]string{"group", "group_base_name", "group_is_latest", "group_version", "topic"}, prometheus.Labels{},
+		[]string{"group", "group_base_name", "group_is_latest", "group_version", "topic"}, opts.ConstLabels,
 	)
 
 	// Topic metrics
 	partitionCountDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(opts.MetricsPrefix, "topic", "partition_count"),
 		"Partition count for a given topic along with cleanup policy as label",
-		[]string{"topic", "cleanup_policy"}, prometheus.Labels{},
+		[]string{"topic", "cleanup_policy"}, opts.ConstLabels,
 	)
 	subscribedGroupsCountDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(opts.MetricsPrefix, "topic", "subscribed_groups_count"),
 		"Number of consumer groups which have at least one consumer group offset for any of the topics partitions",
-		[]string{"topic"}, prometheus.Labels{},
+		[]string{"topic"}, opts.ConstLabels,
 	)
 	topicLogDirSizeDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(opts.MetricsPrefix, "topic", "log_dir_size"),
 		"Size in bytes which is used for the topic's log dirs storage",
-		[]string{"topic"}, prometheus.Labels{},
+		[]string{"topic"}, opts.ConstLabels,
 	)
 
 	// Partition metrics
 	partitionHighWaterMarkDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(opts.MetricsPrefix, "topic_partition", "high_water_mark"),
 		"Highest known committed offset for this partition",
-		[]string{"topic", "partition"}, prometheus.Labels{},
+		[]string{"topic", "partition"}, opts.ConstLabels,
 	)
 	partitionLowWaterMarkDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(opts.MetricsPrefix, "topic_partition", "low_water_mark"),
 		"Oldest known committed offset for this partition",
-		[]string{"topic", "partition"}, prometheus.Labels{},
+		[]string{"topic", "partition"}, opts.ConstLabels,
 	)
 	partitionMessageCountDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(opts.MetricsPrefix, "topic_partition", "message_count"),
 		"Number of messages for a given topic. Calculated by subtracting high water mark by low water mark.",
-		[]string{"topic", "partition"}, prometheus.Labels{},
+		[]string{"topic", "partition"}, opts.ConstLabels,
 	)
 
 	// Broker metrics
 	brokerLogDirSizeDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(opts.MetricsPrefix, "broker", "log_dir_size"),
 		"Size in bytes which is used for the broker's log dirs storage",
-		[]string{"broker_id"}, prometheus.Labels{},
+		[]string{"broker_id"}, opts.ConstLabels,
 	)
 
 	// General metrics

--- a/options/options.go
+++ b/options/options.go
@@ -66,6 +66,9 @@ type Options struct {
 	TLSInsecureSkipTLSVerify bool   `envconfig:"KAFKA_TLS_INSECURE_SKIP_TLS_VERIFY" default:"true"`
 	TLSPassphrase            string `envconfig:"KAFKA_TLS_PASSPHRASE"`
 
+	// Prometheus constant labels which are added to all metrics
+	ConstLabels map[string]string `envconfig:"PROMETHEUS_CONST_LABELS" default:""`
+
 	// Prometheus exporter
 	// MetricsPrefix - A prefix for all exported prometheus metrics
 	MetricsPrefix string `envconfig:"METRICS_PREFIX" default:"kafka_minion"`


### PR DESCRIPTION
This PR resolves #31 by adding the functionality to specify custom global labels which are appended to all kafka-minion metrics.
