### PR TITLE
Add namespace metadata to all k8s resource definitions

### DIFF
--- a/charts/kminion/templates/configmap.yaml
+++ b/charts/kminion/templates/configmap.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{include "kminion.fullname" .}}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "kminion.labels" . | nindent 4}}
 data:

--- a/charts/kminion/templates/deployment.yaml
+++ b/charts/kminion/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{include "kminion.fullname" .}}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "kminion.labels" . | nindent 4}}
     {{- if .Values.customLabels}}

--- a/charts/kminion/templates/hpa.yaml
+++ b/charts/kminion/templates/hpa.yaml
@@ -3,6 +3,7 @@ apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "kminion.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "kminion.labels" . | nindent 4 }}
 spec:

--- a/charts/kminion/templates/ingress.yaml
+++ b/charts/kminion/templates/ingress.yaml
@@ -9,6 +9,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "kminion.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/charts/kminion/templates/service.yaml
+++ b/charts/kminion/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "kminion.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "kminion.labels" . | nindent 4 }}
   {{- if .Values.service.annotations }}

--- a/charts/kminion/templates/serviceaccount.yaml
+++ b/charts/kminion/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "kminion.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "kminion.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/kminion/templates/servicemonitor.yaml
+++ b/charts/kminion/templates/servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{include "kminion.fullname" .}}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "kminion.labels" . | nindent 4}}
     {{- if .Values.serviceMonitor.additionalLabels}}


### PR DESCRIPTION
This is needed in CICD tools where defaulting to namespace is not possible
and a namespace is always required.

This is similar to v1 chart version:
https://github.com/cloudworkz/kafka-minion-helm-chart/commit/c23f1065e1d02517fce1c0a9994fc4b94e6c84ba