### PR TITLE
List offsets for Stable consumer groups only

### DIFF
--- a/minion/consumer_group_offsets.go
+++ b/minion/consumer_group_offsets.go
@@ -24,7 +24,9 @@ func (s *Service) ListAllConsumerGroupOffsetsAdminAPI(ctx context.Context) (map[
 	}
 	groupIDs := make([]string, len(groupsRes.Groups))
 	for i, group := range groupsRes.Groups {
-		groupIDs[i] = group.Group
+		if group.GroupState == "Stable" {
+			groupIDs[i] = group.Group
+		}
 	}
 
 	return s.listConsumerGroupOffsetsBulk(ctx, groupIDs)


### PR DESCRIPTION
Reduce the number of metrics for clusters where lots are consumer groups are short-lived and empty.
The proposed change is to list the consumer group offsets only for Stable groups.