### PR TITLE
add daemonset template

### DIFF
--- a/charts/kminion/templates/daemonset.yaml
+++ b/charts/kminion/templates/daemonset.yaml
@@ -1,0 +1,118 @@
+{{- if .Values.daemonset }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{include "kminion.fullname" .}}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    {{- include "kminion.labels" . | nindent 4}}
+spec:
+  updateStrategy:
+    type: OnDelete
+  selector:
+    matchLabels:
+      {{- include "kminion.selectorLabels" . | nindent 6}}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations}}
+      annotations:
+        {{- toYaml . | nindent 8}}
+      {{- end}}
+      labels:
+        {{- include "kminion.selectorLabels" . | nindent 8}}
+        {{- if .Values.customLabels}}
+        {{toYaml .Values.customLabels | nindent 8}}
+        {{- end}}
+    spec:
+      {{- with .Values.imagePullSecrets}}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8}}
+      {{- end}}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8}}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{include "kminion.fullname" .}}
+        {{- range .Values.deployment.volumes.secrets}}
+        - name: {{.secretName}}
+          secret:
+            secretName: {{.secretName}}
+        {{- end}}
+      containers:
+        - name: {{.Chart.Name}}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12}}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{.Values.image.pullPolicy}}
+          ports:
+            - name: metrics
+              containerPort: {{.Values.service.port}}
+              protocol: TCP
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: CONFIG_FILEPATH
+              value: /etc/kminion/config.yaml
+            {{- range .Values.deployment.env.values}}
+            - name: {{.name}}
+              value: {{.value | quote}}
+            {{- end}}
+            {{- range .Values.deployment.env.secretKeyRefs}}
+            - name: {{.name}}
+              valueFrom:
+                secretKeyRef:
+                  name: {{.secretName}}
+                  key: {{.secretKey}}
+            {{- end}}
+            {{- range .Values.deployment.env.configMapKeyRefs}}
+            - name: {{.name}}
+              valueFrom:
+                configMapKeyRef:
+                  name: {{.configMapName}}
+                  key: {{.configMapKey}}
+            {{- end}}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/kminion
+            {{- range .Values.deployment.volumes.secrets}}
+            - name: {{.secretName}}
+              mountPath: {{.mountPath}}
+            {{- end}}
+          resources:
+            {{- toYaml .Values.resources | nindent 12}}
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /ready
+              port: metrics
+              scheme: HTTP
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /ready
+              port: metrics
+              scheme: HTTP
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+      {{- with .Values.affinity}}
+      affinity:
+        {{- toYaml . | nindent 8}}
+      {{- end}}
+      {{- with .Values.tolerations}}
+      tolerations:
+        {{- toYaml . | nindent 8}}
+      {{- end}}
+{{- end }}

--- a/charts/kminion/values.yaml
+++ b/charts/kminion/values.yaml
@@ -96,6 +96,9 @@ serviceMonitor:
   additionalLabels: {}
   honorLabels: false
 
+# For DaemonSet mode you may set daemonset to "true" and replicaCount to 0.
+daemonset: false
+
 deployment:
   volumes:
     # Mount files from Kubernetes secrets into the container


### PR DESCRIPTION
This adds an option to deploy in daemonset mode, e.g. set:
daemonset: true
replicaCount: 0

Ideally there is a need to move many variables away from "deployment" (or renaming it to more common key), but this require changes in values config for existing deployments, so currently it is being reused.