### PR TITLE
Fix readiness probe

### DIFF
--- a/charts/kminion/templates/deployment.yaml
+++ b/charts/kminion/templates/deployment.yaml
@@ -82,7 +82,7 @@ spec:
             {{- toYaml .Values.resources | nindent 12}}
           readinessProbe:
             httpGet:
-              path: /ready
+              path: /metrics
               port: {{.Values.service.port}}
             initialDelaySeconds: 10
       {{- with .Values.nodeSelector}}


### PR DESCRIPTION
The readiness probe fails right now when trying to deploy it using helmfile. Minion responds with 404 to all path requests excepting /metrics .