### PR TITLE
Update Helm chart with v2.2.0 image tag

### DIFF
--- a/charts/kminion/Chart.yaml
+++ b/charts/kminion/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.2
+version: 0.8.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v2.1.0"
+appVersion: "v2.2.0"


### PR DESCRIPTION
This updates the helm chart with the newer v2.2.0 image. 
The v2.1.0 image does not support the `/ready` endpoint and thus fails the readiness check forever.